### PR TITLE
Remove unnecessary branch from CI push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - public-visibility-pimp
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary

Eliminate the redundant branch from the CI push triggers to streamline the workflow.

## Related Issue

Link the related issue(s):

## Checklist

- [ ] I ran `go fmt ./...`
- [ ] I ran `go vet ./...`
- [ ] I ran `go build ./...`
- [ ] I tested the change locally
- [ ] I updated docs if behavior changed

## Test Notes

Validated the change by ensuring CI triggers function correctly without the removed branch.

## Platform

- [ ] Linux
- [ ] Windows

