### PR TITLE
Make cache size dynamic

### DIFF
--- a/app/upload/caching.go
+++ b/app/upload/caching.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	maxCacheSize = 100
+	MAX_CACHE_SIZE_FACTOR = 2
+	HISTORY_PER_ACCOUNT   = 20
 )
 
 type UploadCache struct {
@@ -20,13 +21,13 @@ type UploadCache struct {
 	max       int
 }
 
-func LoadUploadedCache(indexName string) *UploadCache {
+func LoadUploadedCache(indexName string, nAccount int) *UploadCache {
 	logger.FuncDebug()
 	c := &UploadCache{
 		indexName: indexName,
 		items:     []string{},
 		index:     make(map[string]bool),
-		max:       maxCacheSize,
+		max:       nAccount * HISTORY_PER_ACCOUNT * MAX_CACHE_SIZE_FACTOR,
 	}
 
 	file, err := os.Open(c.cachePath())

--- a/app/upload/uploader.go
+++ b/app/upload/uploader.go
@@ -157,7 +157,7 @@ func (u *Uploader) singleUpload(replayIndex int, websiteIndex int, websites []*W
 		return
 	}
 
-	uploadCache := LoadUploadedCache(website.config.Name)
+	uploadCache := LoadUploadedCache(website.config.Name, len(u.appConfig.AccountSettings.Get()))
 
 	if !uploadCache.index[replay.Match.MatchGUID] {
 		logger.Rlogger.Debug("Uploading replay", slog.Any("matchGUID", replay.Match.MatchGUID), slog.Any("filePath", filePath))


### PR DESCRIPTION
## Summary

Fix cache size that could be reach if more than 5 accounts are made by the user and all of them have 20 matches in history