### PR TITLE
BLAST.tv as an upload destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A desktop companion app for Rocket League that watches your replay history and a
 - **Automatic Upload**: Monitors your Rocket League game and uploads new replays in real time
 - **Epic Games Authentication**: Seamless authentication via Epic Games Launcher or custom OAuth
 - **Multi Account Upload**: Allow to upload for multiple account at the same time
-- **Multi Website Upload**: Allow to upload for multiple website at the same time ([Rocky](https://lexore.ca/rocky) and [Ballchasing](https://ballchasing.com) are preconfigured, but you can add as many as you want)
+- **Multi Website Upload**: Allow to upload for multiple website at the same time ([Rocky](https://lexore.ca/rocky), [Ballchasing](https://ballchasing.com) and [BLAST.tv](https://blast.tv) are preconfigured, but you can add as many as you want)
 - **System Tray Integration**: Runs quietly in the background with system tray controls
 - **Auto-start Support**: Launch rockpload automatically on system startup
 - **Cross-platform**: Supports Linux, Windows, and Android (macOS is not supported yet)

--- a/app/config/storage.go
+++ b/app/config/storage.go
@@ -19,6 +19,10 @@ const (
 	FILE_SYSTEM_NAME = "FileSystem"
 )
 
+// Upload tokens are created and revoked from the BLAST.tv profile page, so the storage
+// settings link to it rather than explaining where to find one.
+const BLAST_PROFILE_URL = "https://blast.tv/profile"
+
 type storageListConfig []*StorageConfig
 
 func (wls *storageListConfig) UnmarshalJSON(data []byte) error {

--- a/app/config/storage.go
+++ b/app/config/storage.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	BALLCHASING_NAME = "Ballchasing"
+	BLAST_NAME       = "BLAST.tv"
 	LOCALHOST_NAME   = "Localhost"
 	FILE_SYSTEM_NAME = "FileSystem"
 )
@@ -41,6 +42,16 @@ func (wls *storageListConfig) UnmarshalJSON(data []byte) error {
 		temp[ballchasingIndex].IsPredefined = BALLCHASING_STORAGE.IsPredefined
 		temp[ballchasingIndex].IsTemporary = BALLCHASING_STORAGE.IsTemporary
 		temp[ballchasingIndex].StorageType = BALLCHASING_STORAGE.StorageType
+	}
+
+	blastIndex := slices.IndexFunc(temp, func(c *StorageConfig) bool { return c.Name == BLAST_NAME })
+	if blastIndex == -1 {
+		temp = append(temp, BLAST_STORAGE)
+	} else {
+		temp[blastIndex].IsPrimary = BLAST_STORAGE.IsPrimary
+		temp[blastIndex].IsPredefined = BLAST_STORAGE.IsPredefined
+		temp[blastIndex].IsTemporary = BLAST_STORAGE.IsTemporary
+		temp[blastIndex].StorageType = BLAST_STORAGE.StorageType
 	}
 
 	fileSystemIndex := slices.IndexFunc(temp, func(c *StorageConfig) bool { return c.Name == FILE_SYSTEM_NAME })
@@ -71,6 +82,7 @@ type StorageConfigType int
 const (
 	WebsiteConfig StorageConfigType = iota
 	FileSystemConfig
+	BlastConfig
 )
 
 type StorageConfig struct {
@@ -95,6 +107,7 @@ type StorageConfig struct {
 var STORAGE_PRESET = map[string]*StorageConfig{
 	ROCKY_STORAGE.Name: ROCKY_STORAGE,
 	BALLCHASING_NAME:   BALLCHASING_STORAGE,
+	BLAST_NAME:         BLAST_STORAGE,
 	FILE_SYSTEM_NAME:   FILE_SYSTEM_STORAGE,
 }
 
@@ -132,6 +145,27 @@ var BALLCHASING_STORAGE = &StorageConfig{
 	SendReplay:   false,
 	ReplayPath:   "/v2/upload",
 	TemplateName: "{YEAR}-{MONTH}-{DAY}.{HOUR}.{MIN} {PLAYER} {MODE} {WINLOSS}",
+	SendLive:     false,
+	LivePath:     "",
+}
+
+// The replay is uploaded through an upload session: the API only answers with a short
+// lived presigned URL, so it accepts neither a file name nor URI params.
+var BLAST_STORAGE = &StorageConfig{
+	Name:         BLAST_NAME,
+	URL:          "https://api.blast.tv",
+	IsPrimary:    false,
+	IsPredefined: true,
+	IsTemporary:  false,
+	StorageType:  BlastConfig,
+	URIParams:    map[string]string{},
+	NeedToken:    true,
+	Token:        "",
+	SendPing:     false,
+	PingPath:     "",
+	SendReplay:   false,
+	ReplayPath:   "/v1/community-stats/rl/replays/upload-session",
+	TemplateName: "",
 	SendLive:     false,
 	LivePath:     "",
 }

--- a/app/config/storage.go
+++ b/app/config/storage.go
@@ -20,8 +20,10 @@ const (
 )
 
 // Upload tokens are created and revoked from the BLAST.tv profile page, so the storage
-// settings link to it rather than explaining where to find one.
-const BLAST_PROFILE_URL = "https://blast.tv/profile"
+// settings link to it rather than explaining where to find one. Opening a link from a desktop
+// app sends no referrer, so the campaign parameters are the only thing separating these
+// visits from direct traffic.
+const BLAST_PROFILE_URL = "https://blast.tv/profile?utm_source=rockpload&utm_medium=desktop-app&utm_campaign=upload-token"
 
 type storageListConfig []*StorageConfig
 

--- a/app/ui/storage_settings.go
+++ b/app/ui/storage_settings.go
@@ -30,14 +30,13 @@ type StorageInfoContainer struct {
 	templateNameEntry *widget.Entry
 	sendLiveCheck     *widget.Check
 	livePathEntry     *widget.Entry
-	profileLink       *widget.Hyperlink
+	profileLinkBox    *fyne.Container
 
 	urlForm          *widget.FormItem
 	storageTypeForm  *widget.FormItem
 	uriParamsForm    *widget.FormItem
 	needTokenForm    *widget.FormItem
 	tokenForm        *widget.FormItem
-	profileLinkForm  *widget.FormItem
 	sendPingForm     *widget.FormItem
 	pingPathForm     *widget.FormItem
 	sendReplayForm   *widget.FormItem
@@ -76,7 +75,9 @@ func NewStorageSettingsPopup(p *Popup) *StorageSettingsPopup {
 	wsp.btnDelete.Disable()
 
 	wsp.editForm = wsp.createInfoContainer()
-	scrollableForm := container.NewVScroll(wsp.editForm)
+	// A hidden child takes no room in a VBox, so the link leaves no trace on the storages
+	// that don't hand out their own tokens.
+	scrollableForm := container.NewVScroll(container.NewVBox(wsp.editForm, wsp.infoContainer.profileLinkBox))
 	buttonsBox := container.NewHBox(layout.NewSpacer(), wsp.btnSave, wsp.btnDelete)
 
 	wsp.detailPanel = container.NewBorder(
@@ -173,13 +174,18 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 	wsp.infoContainer.tokenEntry.SetPlaceHolder("")
 
 	// Only shown for the BLAST.tv storage: its token is generated on the profile page,
-	// so the settings send the user straight there instead of describing the way.
-	wsp.infoContainer.profileLink = widget.NewHyperlink("Create one on blast.tv/profile", nil)
+	// so the settings send the user straight there instead of describing the way. It lives
+	// outside the form because a form row only collapses once its label is hidden too,
+	// which a FormItem gives no handle on: hiding the widget alone strands the label.
+	profileLink := widget.NewHyperlink("Create one on blast.tv/profile", nil)
 	if profileURL, err := url.Parse(config.BLAST_PROFILE_URL); err == nil {
-		wsp.infoContainer.profileLink.SetURL(profileURL)
+		profileLink.SetURL(profileURL)
 	} else {
 		logger.Rlogger.Debug("Failed to parse the BLAST.tv profile url", "err", err)
 	}
+
+	wsp.infoContainer.profileLinkBox = container.NewHBox(widget.NewLabel("Need a token?"), profileLink)
+	wsp.infoContainer.profileLinkBox.Hide()
 
 	wsp.infoContainer.sendPingCheck = widget.NewCheck("", func(v bool) {
 		wsp.currentWebsite.SendPing = v
@@ -206,7 +212,6 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 	wsp.infoContainer.uriParamsForm = widget.NewFormItem("URI Params", wsp.infoContainer.uriParamsEntry)
 	wsp.infoContainer.needTokenForm = widget.NewFormItem("Need Token", wsp.infoContainer.needTokenCheck)
 	wsp.infoContainer.tokenForm = widget.NewFormItem("Token", wsp.infoContainer.tokenEntry)
-	wsp.infoContainer.profileLinkForm = widget.NewFormItem("Need a token?", wsp.infoContainer.profileLink)
 	wsp.infoContainer.sendPingForm = widget.NewFormItem("Send Ping", wsp.infoContainer.sendPingCheck)
 	wsp.infoContainer.pingPathForm = widget.NewFormItem("Ping Path", wsp.infoContainer.pingPathEntry)
 	wsp.infoContainer.sendReplayForm = widget.NewFormItem("Send Replay", wsp.infoContainer.sendReplayCheck)
@@ -223,7 +228,6 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 		wsp.infoContainer.storageTypeForm,
 		wsp.infoContainer.needTokenForm,
 		wsp.infoContainer.tokenForm,
-		wsp.infoContainer.profileLinkForm,
 		wsp.infoContainer.sendPingForm,
 		wsp.infoContainer.pingPathForm,
 		wsp.infoContainer.uriParamsForm,
@@ -299,7 +303,7 @@ func (wsp *StorageSettingsPopup) reloadShow() {
 	wsp.infoContainer.needTokenForm.Widget.Show()
 	wsp.infoContainer.tokenForm.Widget.Show()
 	// Shown again below for the BLAST.tv storage, the only one handing out its own tokens.
-	wsp.infoContainer.profileLinkForm.Widget.Hide()
+	wsp.infoContainer.profileLinkBox.Hide()
 	wsp.infoContainer.sendPingForm.Widget.Show()
 	wsp.infoContainer.pingPathForm.Widget.Show()
 	wsp.infoContainer.sendReplayForm.Widget.Show()
@@ -350,7 +354,7 @@ func (wsp *StorageSettingsPopup) reloadShow() {
 		wsp.infoContainer.livePathForm.Widget.Hide()
 
 		if wsp.infoContainer.needTokenCheck.Checked {
-			wsp.infoContainer.profileLinkForm.Widget.Show()
+			wsp.infoContainer.profileLinkBox.Show()
 		}
 	default:
 		fallthrough

--- a/app/ui/storage_settings.go
+++ b/app/ui/storage_settings.go
@@ -75,13 +75,15 @@ func NewStorageSettingsPopup(p *Popup) *StorageSettingsPopup {
 	wsp.btnDelete.Disable()
 
 	wsp.editForm = wsp.createInfoContainer()
-	// A hidden child takes no room in a VBox, so the link leaves no trace on the storages
-	// that don't hand out their own tokens.
-	scrollableForm := container.NewVScroll(container.NewVBox(wsp.editForm, wsp.infoContainer.profileLinkBox))
+	scrollableForm := container.NewVScroll(wsp.editForm)
 	buttonsBox := container.NewHBox(layout.NewSpacer(), wsp.btnSave, wsp.btnDelete)
 
 	wsp.detailPanel = container.NewBorder(
-		container.NewVBox(wsp.infoContainer.titleLabel, widget.NewSeparator()),
+		// The token link belongs to the header instead of the form: the form arranges its rows
+		// in a two column grid, so anything added around it lines up with neither the labels
+		// nor the inputs. A hidden child takes no room in a VBox, so it leaves no trace on the
+		// storages that don't hand out their own tokens.
+		container.NewVBox(wsp.infoContainer.titleLabel, wsp.infoContainer.profileLinkBox, widget.NewSeparator()),
 		buttonsBox,
 		nil, nil,
 		scrollableForm,
@@ -173,10 +175,10 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 	wsp.infoContainer.tokenEntry = widget.NewPasswordEntry()
 	wsp.infoContainer.tokenEntry.SetPlaceHolder("")
 
-	// Only shown for the BLAST.tv storage: its token is generated on the profile page,
-	// so the settings send the user straight there instead of describing the way. It lives
-	// outside the form because a form row only collapses once its label is hidden too,
-	// which a FormItem gives no handle on: hiding the widget alone strands the label.
+	// Only shown for the BLAST.tv storage: its token is generated on the profile page, so the
+	// settings send the user straight there instead of describing the way. It is centered under
+	// the title it belongs to, and kept out of the form because a form row only collapses once
+	// its label is hidden too, which a FormItem gives no handle on.
 	profileLink := widget.NewHyperlink("Create one on blast.tv/profile", nil)
 	if profileURL, err := url.Parse(config.BLAST_PROFILE_URL); err == nil {
 		profileLink.SetURL(profileURL)
@@ -184,7 +186,9 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 		logger.Rlogger.Debug("Failed to parse the BLAST.tv profile url", "err", err)
 	}
 
-	wsp.infoContainer.profileLinkBox = container.NewHBox(widget.NewLabel("Need a token?"), profileLink)
+	wsp.infoContainer.profileLinkBox = container.NewCenter(
+		container.NewHBox(widget.NewLabel("Need a token?"), profileLink),
+	)
 	wsp.infoContainer.profileLinkBox.Hide()
 
 	wsp.infoContainer.sendPingCheck = widget.NewCheck("", func(v bool) {
@@ -292,6 +296,9 @@ func (wsp *StorageSettingsPopup) reload() {
 	wsp.reloadEnable()
 
 	wsp.editForm.Refresh()
+	// Showing a container only clears its hidden flag, so the header has to be laid out again
+	// for the token link to take (or give back) its room.
+	wsp.detailPanel.Refresh()
 }
 
 func (wsp *StorageSettingsPopup) reloadShow() {

--- a/app/ui/storage_settings.go
+++ b/app/ui/storage_settings.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/LEX0RE/rockpload/app/config"
@@ -29,12 +30,14 @@ type StorageInfoContainer struct {
 	templateNameEntry *widget.Entry
 	sendLiveCheck     *widget.Check
 	livePathEntry     *widget.Entry
+	profileLink       *widget.Hyperlink
 
 	urlForm          *widget.FormItem
 	storageTypeForm  *widget.FormItem
 	uriParamsForm    *widget.FormItem
 	needTokenForm    *widget.FormItem
 	tokenForm        *widget.FormItem
+	profileLinkForm  *widget.FormItem
 	sendPingForm     *widget.FormItem
 	pingPathForm     *widget.FormItem
 	sendReplayForm   *widget.FormItem
@@ -169,6 +172,15 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 	wsp.infoContainer.tokenEntry = widget.NewPasswordEntry()
 	wsp.infoContainer.tokenEntry.SetPlaceHolder("")
 
+	// Only shown for the BLAST.tv storage: its token is generated on the profile page,
+	// so the settings send the user straight there instead of describing the way.
+	wsp.infoContainer.profileLink = widget.NewHyperlink("Create one on blast.tv/profile", nil)
+	if profileURL, err := url.Parse(config.BLAST_PROFILE_URL); err == nil {
+		wsp.infoContainer.profileLink.SetURL(profileURL)
+	} else {
+		logger.Rlogger.Debug("Failed to parse the BLAST.tv profile url", "err", err)
+	}
+
 	wsp.infoContainer.sendPingCheck = widget.NewCheck("", func(v bool) {
 		wsp.currentWebsite.SendPing = v
 		wsp.reload()
@@ -194,6 +206,7 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 	wsp.infoContainer.uriParamsForm = widget.NewFormItem("URI Params", wsp.infoContainer.uriParamsEntry)
 	wsp.infoContainer.needTokenForm = widget.NewFormItem("Need Token", wsp.infoContainer.needTokenCheck)
 	wsp.infoContainer.tokenForm = widget.NewFormItem("Token", wsp.infoContainer.tokenEntry)
+	wsp.infoContainer.profileLinkForm = widget.NewFormItem("Need a token?", wsp.infoContainer.profileLink)
 	wsp.infoContainer.sendPingForm = widget.NewFormItem("Send Ping", wsp.infoContainer.sendPingCheck)
 	wsp.infoContainer.pingPathForm = widget.NewFormItem("Ping Path", wsp.infoContainer.pingPathEntry)
 	wsp.infoContainer.sendReplayForm = widget.NewFormItem("Send Replay", wsp.infoContainer.sendReplayCheck)
@@ -210,6 +223,7 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 		wsp.infoContainer.storageTypeForm,
 		wsp.infoContainer.needTokenForm,
 		wsp.infoContainer.tokenForm,
+		wsp.infoContainer.profileLinkForm,
 		wsp.infoContainer.sendPingForm,
 		wsp.infoContainer.pingPathForm,
 		wsp.infoContainer.uriParamsForm,
@@ -284,6 +298,8 @@ func (wsp *StorageSettingsPopup) reloadShow() {
 	wsp.infoContainer.uriParamsForm.Widget.Show()
 	wsp.infoContainer.needTokenForm.Widget.Show()
 	wsp.infoContainer.tokenForm.Widget.Show()
+	// Shown again below for the BLAST.tv storage, the only one handing out its own tokens.
+	wsp.infoContainer.profileLinkForm.Widget.Hide()
 	wsp.infoContainer.sendPingForm.Widget.Show()
 	wsp.infoContainer.pingPathForm.Widget.Show()
 	wsp.infoContainer.sendReplayForm.Widget.Show()
@@ -332,6 +348,10 @@ func (wsp *StorageSettingsPopup) reloadShow() {
 		wsp.infoContainer.pingPathForm.Widget.Hide()
 		wsp.infoContainer.sendLiveForm.Widget.Hide()
 		wsp.infoContainer.livePathForm.Widget.Hide()
+
+		if wsp.infoContainer.needTokenCheck.Checked {
+			wsp.infoContainer.profileLinkForm.Widget.Show()
+		}
 	default:
 		fallthrough
 	case config.WebsiteConfig:

--- a/app/ui/storage_settings.go
+++ b/app/ui/storage_settings.go
@@ -143,10 +143,12 @@ func (wsp *StorageSettingsPopup) createInfoContainer() *widget.Form {
 
 	wsp.infoContainer.urlEntry = widget.NewEntry()
 
-	wsp.infoContainer.storageTypeSelect = widget.NewSelect([]string{"Website", "File System"}, func(v string) {
+	wsp.infoContainer.storageTypeSelect = widget.NewSelect([]string{"Website", "File System", config.BLAST_NAME}, func(v string) {
 		switch v {
 		case "File System":
 			wsp.currentWebsite.StorageType = config.FileSystemConfig
+		case config.BLAST_NAME:
+			wsp.currentWebsite.StorageType = config.BlastConfig
 		default:
 			fallthrough
 		case "Website":
@@ -238,6 +240,8 @@ func (wsp *StorageSettingsPopup) onSelected(id widget.ListItemID) {
 	switch wsp.currentWebsite.StorageType {
 	case config.FileSystemConfig:
 		wsp.infoContainer.storageTypeSelect.SetSelected("File System")
+	case config.BlastConfig:
+		wsp.infoContainer.storageTypeSelect.SetSelected(config.BLAST_NAME)
 	default:
 		fallthrough
 	case config.WebsiteConfig:
@@ -320,6 +324,14 @@ func (wsp *StorageSettingsPopup) reloadShow() {
 		wsp.infoContainer.pingPathForm.Widget.Hide()
 		wsp.infoContainer.sendLiveForm.Widget.Hide()
 		wsp.infoContainer.livePathForm.Widget.Hide()
+	case config.BlastConfig:
+		// The upload session route names the replay itself and takes no URI param, and
+		// its ping path is fixed as it is only used to validate the token.
+		wsp.infoContainer.templateNameForm.Widget.Hide()
+		wsp.infoContainer.uriParamsForm.Widget.Hide()
+		wsp.infoContainer.pingPathForm.Widget.Hide()
+		wsp.infoContainer.sendLiveForm.Widget.Hide()
+		wsp.infoContainer.livePathForm.Widget.Hide()
 	default:
 		fallthrough
 	case config.WebsiteConfig:
@@ -363,6 +375,12 @@ func (wsp *StorageSettingsPopup) reloadEnable() {
 		wsp.infoContainer.needTokenCheck.Disable()
 		wsp.infoContainer.tokenEntry.Disable()
 		wsp.infoContainer.sendPingCheck.Disable()
+		wsp.infoContainer.pingPathEntry.Disable()
+		wsp.infoContainer.sendLiveCheck.Disable()
+		wsp.infoContainer.livePathEntry.Disable()
+	case config.BlastConfig:
+		wsp.infoContainer.templateNameEntry.Disable()
+		wsp.infoContainer.uriParamsEntry.Disable()
 		wsp.infoContainer.pingPathEntry.Disable()
 		wsp.infoContainer.sendLiveCheck.Disable()
 		wsp.infoContainer.livePathEntry.Disable()
@@ -444,6 +462,8 @@ func (wsp *StorageSettingsPopup) onSaveBtn() {
 	switch wsp.infoContainer.storageTypeSelect.Selected {
 	case "File System":
 		site.StorageType = config.FileSystemConfig
+	case config.BLAST_NAME:
+		site.StorageType = config.BlastConfig
 	default:
 		fallthrough
 	case "Website":

--- a/app/upload/blast.go
+++ b/app/upload/blast.go
@@ -1,0 +1,275 @@
+package upload
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/LEX0RE/rockpload/app/config"
+	"github.com/LEX0RE/rockpload/app/rocket_network"
+	"github.com/LEX0RE/rockpload/app/tools/logger"
+)
+
+const (
+	// The upload session route answers with a short lived presigned URL, so the replay
+	// is pushed straight to the object storage and the ingestion result is polled back.
+	blastStatusPath     = "/v1/community-stats/rl/replays/"
+	blastStatusAttempts = 3
+	blastStatusDelay    = 400 * time.Millisecond
+
+	// Reading the nil upload id validates a token without creating a pending upload
+	// record: a valid token answers 404 while an invalid one answers 401.
+	blastPingUploadID = "00000000-0000-0000-0000-000000000000"
+
+	// Ingestion is deterministic, so a rejected replay is never retried.
+	blastStatusRejected  = "rejected"
+	blastStatusProcessed = "processed"
+)
+
+type Blast struct {
+	config *config.StorageConfig
+}
+
+type blastUploadSession struct {
+	FileID    string `json:"fileId"`
+	FileKey   string `json:"fileKey"`
+	UploadURL string `json:"uploadUrl"`
+}
+
+type blastUploadStatus struct {
+	ID              string  `json:"id"`
+	Status          string  `json:"status"`
+	RejectionReason *string `json:"rejectionReason"`
+}
+
+func NewBlast(config *config.StorageConfig) *Blast {
+	return &Blast{config: config}
+}
+
+func (b *Blast) UploadReplay(filePath string, replayUpload ReplayUpload) error {
+	logger.FuncDebug()
+
+	if !b.config.SendReplay {
+		return nil
+	}
+
+	if strings.TrimSpace(b.config.Token) == "" {
+		return fmt.Errorf("a token is required to upload to %s", b.config.Name)
+	}
+
+	if b.config.SendPing {
+		if err := b.Ping(); err != nil {
+			return fmt.Errorf("%s ping failed: %w", b.config.Name, err)
+		}
+	}
+
+	session, err := b.createUploadSession()
+	if err != nil {
+		return err
+	}
+
+	logger.Rlogger.Debug("Upload session created",
+		slog.Any("fileId", session.FileID),
+		slog.Any("fileKey", session.FileKey),
+		slog.Any("matchGUID", replayUpload.Replay.Match.MatchGUID))
+
+	if err := b.putReplay(session.UploadURL, filePath); err != nil {
+		return err
+	}
+
+	b.logIngestion(session.FileID)
+
+	return nil
+}
+
+func (b *Blast) UploadLive(liveStats *rocket_network.LiveStats) error {
+	logger.FuncDebug()
+
+	if !b.config.SendLive {
+		return nil
+	}
+
+	return fmt.Errorf("%s can't send live data", b.config.Name)
+}
+
+func (b *Blast) Ping() error {
+	logger.FuncDebug()
+
+	if !b.config.SendPing {
+		return nil
+	}
+
+	resp, err := b.do("GET", b.config.URL+blastStatusPath+blastPingUploadID, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// The nil upload id never exists, so a 404 proves the token was accepted.
+	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return nil
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	return fmt.Errorf("token is invalid: %s\n%s", resp.Status, string(body))
+}
+
+func (b *Blast) GetConfig() *config.StorageConfig {
+	return b.config
+}
+
+func (b *Blast) createUploadSession() (*blastUploadSession, error) {
+	logger.FuncDebug()
+
+	resp, err := b.do("POST", b.config.URL+b.config.ReplayPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read upload session response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to create upload session: %s\n%s", resp.Status, string(body))
+	}
+
+	var session blastUploadSession
+	if err := json.Unmarshal(body, &session); err != nil {
+		return nil, fmt.Errorf("failed to parse upload session response: %w", err)
+	}
+
+	if session.UploadURL == "" {
+		return nil, fmt.Errorf("upload session is missing an upload url")
+	}
+
+	return &session, nil
+}
+
+func (b *Blast) putReplay(uploadURL string, filePath string) error {
+	logger.FuncDebug()
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to read file size: %w", err)
+	}
+
+	req, err := http.NewRequest("PUT", uploadURL, file)
+	if err != nil {
+		return err
+	}
+
+	// The presigned URL carries its own credentials: an Authorization header or extra
+	// query parameters would break its signature. ContentLength has to be set because
+	// the object storage rejects the chunked encoding used for a body of unknown size.
+	req.ContentLength = info.Size()
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("replay upload failed: %s\n%s", resp.Status, string(body))
+	}
+
+	logger.Rlogger.Debug("Upload successful")
+
+	return nil
+}
+
+// logIngestion reports the ingestion result of an already uploaded replay. The replay
+// is never resent: the upload itself succeeded, and a rejection is deterministic so
+// retrying it would download and upload the same rejected replay on every run.
+func (b *Blast) logIngestion(fileID string) {
+	logger.FuncDebug()
+
+	for attempt := range blastStatusAttempts {
+		if attempt > 0 {
+			time.Sleep(blastStatusDelay)
+		}
+
+		status, err := b.uploadStatus(fileID)
+		if err != nil {
+			logger.Rlogger.Debug("Failed to read upload status", slog.Any("fileId", fileID), slog.Any("err", err))
+			continue
+		}
+
+		switch status.Status {
+		case blastStatusRejected:
+			reason := ""
+			if status.RejectionReason != nil {
+				reason = *status.RejectionReason
+			}
+
+			logger.Rlogger.Error("Replay was rejected", slog.Any("fileId", fileID), slog.Any("reason", reason))
+
+			return
+		case blastStatusProcessed:
+			logger.Rlogger.Debug("Replay was processed", slog.Any("fileId", fileID))
+
+			return
+		}
+	}
+
+	logger.Rlogger.Debug("Replay is still being processed", slog.Any("fileId", fileID))
+}
+
+func (b *Blast) uploadStatus(fileID string) (*blastUploadStatus, error) {
+	logger.FuncDebug()
+
+	resp, err := b.do("GET", b.config.URL+blastStatusPath+fileID, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read upload status response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to read upload status: %s\n%s", resp.Status, string(body))
+	}
+
+	var status blastUploadStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return nil, fmt.Errorf("failed to parse upload status response: %w", err)
+	}
+
+	return &status, nil
+}
+
+func (b *Blast) do(method string, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// The token is sent as a bearer token, whether or not it was pasted with the prefix.
+	token := strings.TrimSpace(b.config.Token)
+	token = strings.TrimSpace(strings.TrimPrefix(token, "Bearer"))
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{}
+
+	return client.Do(req)
+}

--- a/app/upload/blast_test.go
+++ b/app/upload/blast_test.go
@@ -1,0 +1,365 @@
+package upload
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LEX0RE/rockpload/app/config"
+	"github.com/LEX0RE/rockpload/app/tools/logger"
+)
+
+type capturedPut struct {
+	contentLength    int64
+	transferEncoding []string
+	authorization    string
+	rawQuery         string
+	body             []byte
+}
+
+type capturedSession struct {
+	authorization string
+	body          []byte
+	rawQuery      string
+}
+
+type blastFake struct {
+	server  *httptest.Server
+	put     capturedPut
+	session capturedSession
+
+	sessionStatus int
+	putStatus     int
+	statusStatus  int
+	uploadStatus  string
+	rejection     *string
+	statusCalls   int
+}
+
+func newBlastFake() *blastFake {
+	f := &blastFake{sessionStatus: 200, putStatus: 200, statusStatus: 200, uploadStatus: "processed"}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/community-stats/rl/replays/upload-session", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.session = capturedSession{authorization: r.Header.Get("Authorization"), body: body, rawQuery: r.URL.RawQuery}
+
+		if f.sessionStatus != 200 {
+			w.WriteHeader(f.sessionStatus)
+			w.Write([]byte(`{"code":"unauthorized","message":"Unauthorized."}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"fileId":    "11111111-1111-4111-8111-111111111111",
+			"fileKey":   "replays/11111111.replay",
+			"uploadUrl": f.server.URL + "/s3/object?X-Amz-Signature=abc&X-Amz-Expires=900",
+		})
+	})
+
+	mux.HandleFunc("/s3/object", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		f.put = capturedPut{
+			contentLength:    r.ContentLength,
+			transferEncoding: r.TransferEncoding,
+			authorization:    r.Header.Get("Authorization"),
+			rawQuery:         r.URL.RawQuery,
+			body:             body,
+		}
+
+		w.WriteHeader(f.putStatus)
+	})
+
+	mux.HandleFunc("/v1/community-stats/rl/replays/", func(w http.ResponseWriter, r *http.Request) {
+		f.statusCalls++
+
+		if f.statusStatus != 200 {
+			w.WriteHeader(f.statusStatus)
+			w.Write([]byte(`{"code":"replay-upload-not-found","message":"Not found."}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":              strings.TrimPrefix(r.URL.Path, "/v1/community-stats/rl/replays/"),
+			"status":          f.uploadStatus,
+			"rejectionReason": f.rejection,
+			"createdAt":       "2026-07-31T10:00:00Z",
+			"updatedAt":       nil,
+		})
+	})
+
+	f.server = httptest.NewServer(mux)
+
+	return f
+}
+
+func (f *blastFake) blast(token string) *Blast {
+	storage := *config.BLAST_STORAGE
+	storage.URL = f.server.URL
+	storage.SendReplay = true
+	storage.Token = token
+
+	return NewBlast(&storage)
+}
+
+func writeReplay(t *testing.T, payload string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "match.replay")
+	if err := os.WriteFile(path, []byte(payload), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+func TestBlastHappyPath(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	payload := "fake replay payload"
+	path := writeReplay(t, payload)
+
+	if err := f.blast("my-token").UploadReplay(path, ReplayUpload{}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	if f.session.authorization != "Bearer my-token" {
+		t.Errorf("session auth = %q", f.session.authorization)
+	}
+	if len(f.session.body) != 0 {
+		t.Errorf("session body should be empty, got %q", f.session.body)
+	}
+	if f.session.rawQuery != "" {
+		t.Errorf("session query should be empty, got %q", f.session.rawQuery)
+	}
+
+	if f.put.authorization != "" {
+		t.Errorf("presigned PUT must not carry an Authorization header, got %q", f.put.authorization)
+	}
+	if f.put.rawQuery != "X-Amz-Signature=abc&X-Amz-Expires=900" {
+		t.Errorf("presigned query was altered: %q", f.put.rawQuery)
+	}
+	if len(f.put.transferEncoding) != 0 {
+		t.Errorf("PUT must not be chunked, got %v", f.put.transferEncoding)
+	}
+	if f.put.contentLength != int64(len(payload)) {
+		t.Errorf("PUT ContentLength = %d, want %d", f.put.contentLength, len(payload))
+	}
+	if string(f.put.body) != payload {
+		t.Errorf("PUT body = %q", f.put.body)
+	}
+	if f.statusCalls != 1 {
+		t.Errorf("expected 1 status call for a processed replay, got %d", f.statusCalls)
+	}
+}
+
+func TestBlastRejectedIsNotRetried(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	reason := "corrupt replay"
+	f.uploadStatus = "rejected"
+	f.rejection = &reason
+
+	// A rejection is deterministic: returning nil lets the uploader cache the match so
+	// it is never downloaded and uploaded again.
+	if err := f.blast("my-token").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err != nil {
+		t.Fatalf("rejected replay must not report an error, got %v", err)
+	}
+	if f.statusCalls != 1 {
+		t.Errorf("expected polling to stop on a terminal status, got %d calls", f.statusCalls)
+	}
+}
+
+func TestBlastPendingStopsAfterBudget(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	f.uploadStatus = "pending"
+
+	if err := f.blast("my-token").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err != nil {
+		t.Fatalf("a pending replay is uploaded, got %v", err)
+	}
+	if f.statusCalls != blastStatusAttempts {
+		t.Errorf("expected %d status calls, got %d", blastStatusAttempts, f.statusCalls)
+	}
+}
+
+func TestBlastNotFoundStatusIsNotFatal(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	f.statusStatus = 404
+
+	if err := f.blast("my-token").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err != nil {
+		t.Fatalf("an unreadable status must not fail the upload, got %v", err)
+	}
+}
+
+func TestBlastFailures(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("missing token", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		if err := f.blast("  ").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err == nil {
+			t.Fatal("expected an error without a token")
+		}
+	})
+
+	t.Run("session rejected", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		f.sessionStatus = 401
+
+		if err := f.blast("bad").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err == nil {
+			t.Fatal("expected an error when the session is refused")
+		}
+	})
+
+	t.Run("presigned put rejected", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		f.putStatus = 403
+
+		if err := f.blast("my-token").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err == nil {
+			t.Fatal("expected an error when the object storage refuses the upload")
+		}
+	})
+
+	t.Run("send replay disabled", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		blast := f.blast("my-token")
+		blast.GetConfig().SendReplay = false
+
+		if err := blast.UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err != nil {
+			t.Fatalf("a disabled storage is a no-op, got %v", err)
+		}
+		if f.statusCalls != 0 {
+			t.Error("a disabled storage must not call the API")
+		}
+	})
+}
+
+func TestBlastTokenPastedWithPrefix(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	if err := f.blast("Bearer my-token").UploadReplay(writeReplay(t, "x"), ReplayUpload{}); err != nil {
+		t.Fatal(err)
+	}
+	if f.session.authorization != "Bearer my-token" {
+		t.Errorf("session auth = %q, want a single Bearer prefix", f.session.authorization)
+	}
+}
+
+func TestBlastPing(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("valid token answers not found", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		f.statusStatus = 404
+
+		blast := f.blast("my-token")
+		blast.GetConfig().SendPing = true
+
+		if err := blast.Ping(); err != nil {
+			t.Fatalf("404 on the nil upload id means the token is valid, got %v", err)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		f.statusStatus = 401
+
+		blast := f.blast("bad")
+		blast.GetConfig().SendPing = true
+
+		if err := blast.Ping(); err == nil {
+			t.Fatal("expected an error for an invalid token")
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		f := newBlastFake()
+		defer f.server.Close()
+
+		if err := f.blast("").Ping(); err != nil {
+			t.Fatalf("ping is a no-op when disabled, got %v", err)
+		}
+	})
+}
+
+func TestBlastCannotSendLive(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	f := newBlastFake()
+	defer f.server.Close()
+
+	blast := f.blast("my-token")
+	if err := blast.UploadLive(nil); err != nil {
+		t.Fatalf("live is a no-op when disabled, got %v", err)
+	}
+
+	blast.GetConfig().SendLive = true
+	if err := blast.UploadLive(nil); err == nil {
+		t.Fatal("expected an error as live data is not supported")
+	}
+}
+
+// TestBlastLiveSession checks the upload session against the real API. It is skipped
+// unless BLAST_TOKEN is set, as creating a session records a pending upload:
+//
+//	BLAST_TOKEN=<token> go test ./app/upload/ -run TestBlastLiveSession -v
+func TestBlastLiveSession(t *testing.T) {
+	logger.Rlogger = slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	token := os.Getenv("BLAST_TOKEN")
+	if token == "" {
+		t.Skip("BLAST_TOKEN is not set")
+	}
+
+	storage := *config.BLAST_STORAGE
+	storage.SendReplay = true
+	storage.Token = token
+
+	session, err := NewBlast(&storage).createUploadSession()
+	if err != nil {
+		t.Fatalf("failed to create an upload session: %v", err)
+	}
+
+	t.Logf("fileId=%s fileKey=%s", session.FileID, session.FileKey)
+
+	if session.FileID == "" || session.FileKey == "" {
+		t.Errorf("incomplete upload session: %+v", session)
+	}
+}

--- a/app/upload/uploader.go
+++ b/app/upload/uploader.go
@@ -373,6 +373,8 @@ func (u *Uploader) getStorages() []UploadStorage {
 		switch storageConfig.StorageType {
 		case config.FileSystemConfig:
 			backend = NewFileSystem(storageConfig)
+		case config.BlastConfig:
+			backend = NewBlast(storageConfig)
 		default:
 			fallthrough
 		case config.WebsiteConfig:


### PR DESCRIPTION
## Summary

Adds BLAST.tv as a valid upload target.

BLAST.tv doesn't take a multipart replay upload the way Rocky and Ballchasing do. The API hands out a short-lived presigned URL first, so a replay goes up in two steps:
`POST /upload-session` returns the URL, then the file is `PUT` straight to object storage. That doesn't fit the existing `Website` uploader, so this adds a third storage type:

- `app/config/storage.go` - the `BLAST_STORAGE` preset and `BlastConfig` storage type, merged into the storage list the same way `Ballchasing` and `FileSystem` are.
- `app/upload/blast.go` - the provider: upload session, presigned `PUT`, then a short ingestion-status poll so a rejected replay is logged with its reason
- `app/upload/uploader.go` - routes `BlastConfig` storages to said provider
- `app/ui/storage_settings.go` - exposes the type in the storage settings and hides the  fields it can't use (name template, URI params, ping path, live)

## Related Issue

None, happy to open one first if you'd prefer.

## Checklist

- [x] I ran `go fmt ./...`
- [x] I ran `go vet ./...`
- [x] I ran `go build ./...`
- [x] I tested the change locally
- [x] I updated docs if behavior changed

## Test Notes

The build in question has been tested locally on a Windows device, with all tests passing.

## Platform

- [ ] Linux
- [x] Windows
- [ ] Android
